### PR TITLE
Repara enlaces rotos en la sección de iniciativas

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -262,7 +262,7 @@
 
             <div class="columns mt-60 has-text-centered desktop ">
                 <div class="column is-3 is-green">
-                    <a target="_blank" href="https:/mx.frenalacurva.net/c/cuidados">
+                    <a target="_blank" href="https://mx.frenalacurva.net/c/cuidados">
                         <img src="assets/img/illustrations/iniciativas/1.png" alt="Cuidados" class="maxw-img">
                         <p class="subtitle is-5 is-bold is-lightpurple">
                             Cuidados
@@ -286,7 +286,7 @@
                     </a>
                 </div>
                 <div class="column is-3 is-green">
-                    <a target="_blank" href="https:/mx.frenalacurva.net/c/educacion-para-aprender ">
+                    <a target="_blank" href="https://mx.frenalacurva.net/c/educacion-para-aprender ">
                         <img src="assets/img/illustrations/iniciativas/4.png" alt="Educación / Para aprender" class="maxw-img">
                         <p class="subtitle is-5 is-bold raised is-orange">
                             Educación / Para aprender

--- a/src/partials/iniciativas.html
+++ b/src/partials/iniciativas.html
@@ -7,7 +7,7 @@
 
         <div class="columns mt-60 has-text-centered desktop ">
             <div class="column is-3 is-green">
-                <a target="_blank" href="https:/mx.frenalacurva.net/c/cuidados">
+                <a target="_blank" href="https://mx.frenalacurva.net/c/cuidados">
                     <img src="assets/img/illustrations/iniciativas/1.png" alt="Cuidados" class="maxw-img">
                     <p class="subtitle is-5 is-bold is-lightpurple">
                         Cuidados
@@ -31,7 +31,7 @@
                 </a>
             </div>
             <div class="column is-3 is-green">
-                <a target="_blank" href="https:/mx.frenalacurva.net/c/educacion-para-aprender ">
+                <a target="_blank" href="https://mx.frenalacurva.net/c/educacion-para-aprender ">
                     <img src="assets/img/illustrations/iniciativas/4.png" alt="Educación / Para aprender" class="maxw-img">
                     <p class="subtitle is-5 is-bold raised is-orange">
                         Educación / Para aprender


### PR DESCRIPTION
A un par de enlaces les faltaba una `/` en la dirección, por lo
que terminabas en una página inexistente:

<img width="472" alt="Screen Shot 2020-03-27 at 17 58 56" src="https://user-images.githubusercontent.com/1796036/77809358-d2895200-7054-11ea-8c21-328a1d06c708.png">
